### PR TITLE
backmerge: v1.16.0 → develop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -222,10 +222,16 @@ podman-compose run --rm dev uv run python <script>  # Run any script
 - `figures/*.jpg` - Generated from Mermaid `.mmd` sources (JPG format for cross-platform consistency)
 - Versioned for reproducibility and release tagging
 
-**Figure generation:** Generate JPG from Mermaid source with:
+**Figure generation:** Generate JPG from Mermaid source:
 ```bash
+# Step 1: Generate PNG from Mermaid
 npx --yes @mermaid-js/mermaid-cli@latest -i figures/<name>.mmd -o figures/<name>.png
+
+# Step 2: Convert PNG to JPG (choose based on OS)
+# macOS:
 sips -s format jpeg figures/<name>.png --out figures/<name>.jpg && rm figures/<name>.png
+# Linux/Container:
+convert figures/<name>.png figures/<name>.jpg && rm figures/<name>.png
 ```
 
 **Excluded via .gitignore:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,10 +222,16 @@ podman-compose run --rm dev uv run python <script>  # Run any script
 - `figures/*.jpg` - Generated from Mermaid `.mmd` sources (JPG format for cross-platform consistency)
 - Versioned for reproducibility and release tagging
 
-**Figure generation:** Generate JPG from Mermaid source with:
+**Figure generation:** Generate JPG from Mermaid source:
 ```bash
+# Step 1: Generate PNG from Mermaid
 npx --yes @mermaid-js/mermaid-cli@latest -i figures/<name>.mmd -o figures/<name>.png
+
+# Step 2: Convert PNG to JPG (choose based on OS)
+# macOS:
 sips -s format jpeg figures/<name>.png --out figures/<name>.jpg && rm figures/<name>.png
+# Linux/Container:
+convert figures/<name>.png figures/<name>.jpg && rm figures/<name>.png
 ```
 
 **Excluded via .gitignore:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,10 +222,16 @@ podman-compose run --rm dev uv run python <script>  # Run any script
 - `figures/*.jpg` - Generated from Mermaid `.mmd` sources (JPG format for cross-platform consistency)
 - Versioned for reproducibility and release tagging
 
-**Figure generation:** Generate JPG from Mermaid source with:
+**Figure generation:** Generate JPG from Mermaid source:
 ```bash
+# Step 1: Generate PNG from Mermaid
 npx --yes @mermaid-js/mermaid-cli@latest -i figures/<name>.mmd -o figures/<name>.png
+
+# Step 2: Convert PNG to JPG (choose based on OS)
+# macOS:
 sips -s format jpeg figures/<name>.png --out figures/<name>.jpg && rm figures/<name>.png
+# Linux/Container:
+convert figures/<name>.png figures/<name>.jpg && rm figures/<name>.png
 ```
 
 **Excluded via .gitignore:**


### PR DESCRIPTION
## Summary

Backmerge release v1.16.0 to develop.

Keeps develop in sync with production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)