### PR TITLE
fix(ci): python3 fallback in validate_documentation.sh

### DIFF
--- a/tools/validation/validate_documentation.sh
+++ b/tools/validation/validate_documentation.sh
@@ -59,14 +59,14 @@ echo ""
 
 # Detect Python runner (uv run python if available, else python3)
 if command -v uv &> /dev/null; then
-    PYTHON_CMD="uv run python"
+    PYTHON_CMD=("uv" "run" "python")
 else
-    PYTHON_CMD="python3"
+    PYTHON_CMD=("python3")
 fi
 
 # Test 6: Reference validation (citations and URLs)
 echo "Test 6: Reference validation"
-$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-citations
+"${PYTHON_CMD[@]}" "$REPO_ROOT/scripts/validate_references.py" --check-citations
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ Reference validation failed"
@@ -77,7 +77,7 @@ echo ""
 
 # Test 7: LaTeX-in-URL validation
 echo "Test 7: LaTeX-in-URL validation"
-$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-latex
+"${PYTHON_CMD[@]}" "$REPO_ROOT/scripts/validate_references.py" --check-latex
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ LaTeX-in-URL validation failed"

--- a/tools/validation/validate_documentation.sh
+++ b/tools/validation/validate_documentation.sh
@@ -57,9 +57,16 @@ if [ $? -ne 0 ]; then
 fi
 echo ""
 
+# Detect Python runner (uv run python if available, else python3)
+if command -v uv &> /dev/null; then
+    PYTHON_CMD="uv run python"
+else
+    PYTHON_CMD="python3"
+fi
+
 # Test 6: Reference validation (citations and URLs)
 echo "Test 6: Reference validation"
-uv run python "$REPO_ROOT/scripts/validate_references.py" --check-citations
+$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-citations
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ Reference validation failed"
@@ -70,7 +77,7 @@ echo ""
 
 # Test 7: LaTeX-in-URL validation
 echo "Test 7: LaTeX-in-URL validation"
-uv run python "$REPO_ROOT/scripts/validate_references.py" --check-latex
+$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-latex
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ LaTeX-in-URL validation failed"


### PR DESCRIPTION
Fixes Documentation Validation CI failure on main. The script now
detects whether uv is available and falls back to python3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)