### PR TITLE
release: v2.0.1 - fix CI Documentation Validation

### DIFF
--- a/tools/validation/validate_documentation.sh
+++ b/tools/validation/validate_documentation.sh
@@ -59,14 +59,14 @@ echo ""
 
 # Detect Python runner (uv run python if available, else python3)
 if command -v uv &> /dev/null; then
-    PYTHON_CMD="uv run python"
+    PYTHON_CMD=("uv" "run" "python")
 else
-    PYTHON_CMD="python3"
+    PYTHON_CMD=("python3")
 fi
 
 # Test 6: Reference validation (citations and URLs)
 echo "Test 6: Reference validation"
-$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-citations
+"${PYTHON_CMD[@]}" "$REPO_ROOT/scripts/validate_references.py" --check-citations
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ Reference validation failed"
@@ -77,7 +77,7 @@ echo ""
 
 # Test 7: LaTeX-in-URL validation
 echo "Test 7: LaTeX-in-URL validation"
-$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-latex
+"${PYTHON_CMD[@]}" "$REPO_ROOT/scripts/validate_references.py" --check-latex
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ LaTeX-in-URL validation failed"

--- a/tools/validation/validate_documentation.sh
+++ b/tools/validation/validate_documentation.sh
@@ -57,13 +57,15 @@ if [ $? -ne 0 ]; then
 fi
 echo ""
 
-# Detect Python runner (uv run python if available, else python3)
+# Detect Python runner (prefer uv, then python3, then python)
 if command -v uv &> /dev/null; then
     PYTHON_CMD=("uv" "run" "python")
 elif command -v python3 &> /dev/null; then
     PYTHON_CMD=("python3")
+elif command -v python &> /dev/null; then
+    PYTHON_CMD=("python")
 else
-    echo "ERROR: Neither 'uv' nor 'python3' found. Install one to run reference validation."
+    echo "ERROR: No Python interpreter found (tried uv, python3, python). Install one to run reference validation."
     exit 1
 fi
 

--- a/tools/validation/validate_documentation.sh
+++ b/tools/validation/validate_documentation.sh
@@ -57,9 +57,16 @@ if [ $? -ne 0 ]; then
 fi
 echo ""
 
+# Detect Python runner (uv run python if available, else python3)
+if command -v uv &> /dev/null; then
+    PYTHON_CMD="uv run python"
+else
+    PYTHON_CMD="python3"
+fi
+
 # Test 6: Reference validation (citations and URLs)
 echo "Test 6: Reference validation"
-uv run python "$REPO_ROOT/scripts/validate_references.py" --check-citations
+$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-citations
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ Reference validation failed"
@@ -70,7 +77,7 @@ echo ""
 
 # Test 7: LaTeX-in-URL validation
 echo "Test 7: LaTeX-in-URL validation"
-uv run python "$REPO_ROOT/scripts/validate_references.py" --check-latex
+$PYTHON_CMD "$REPO_ROOT/scripts/validate_references.py" --check-latex
 if [ $? -ne 0 ]; then
     ((total_errors++))
     echo "  ❌ LaTeX-in-URL validation failed"

--- a/tools/validation/validate_documentation.sh
+++ b/tools/validation/validate_documentation.sh
@@ -60,8 +60,11 @@ echo ""
 # Detect Python runner (uv run python if available, else python3)
 if command -v uv &> /dev/null; then
     PYTHON_CMD=("uv" "run" "python")
-else
+elif command -v python3 &> /dev/null; then
     PYTHON_CMD=("python3")
+else
+    echo "ERROR: Neither 'uv' nor 'python3' found. Install one to run reference validation."
+    exit 1
 fi
 
 # Test 6: Reference validation (citations and URLs)


### PR DESCRIPTION
## Release v2.0.1

Hotfix: Documentation Validation CI was failing on main because
`validate_documentation.sh` used `uv run python` but CI doesn't
have `uv` installed. Now uses bash array with python3 fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)