### PR TITLE
Backmerge v3.0.0 to develop

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,8 @@ keywords:
   - organizational resilience
   - HIMSS AMAM
 license: Apache-2.0
-version: 2.2.1
-date-released: '2026-04-13'
+version: 3.0.0
+date-released: '2026-06-16'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.18264359

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yuiquery-research"
-version = "2.1.0"
+version = "3.0.0"
 description = "YuiQuery Healthcare Analytics Research - Natural Language to SQL in Healthcare"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1722,7 +1722,7 @@ wheels = [
 
 [[package]]
 name = "yuiquery-research"
-version = "2.1.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Backmerge the v3.0.0 release (version bump in pyproject.toml / CITATION.cff / uv.lock) from `release/v3.0.0` into `develop` so develop carries the released version. Autonomous backmerge per the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)